### PR TITLE
Add drop.missing.meta argument to tokenbrowser 

### DIFF
--- a/R/html_misc.r
+++ b/R/html_misc.r
@@ -74,7 +74,7 @@ create_meta_tables <- function(meta, ignore_col=NULL, drop.missing=FALSE) {
       if (col %in% ignore_col) next
       colval = as.character(meta[[col]])
       if (!drop.missing) colval[is.na(colval)] = ''
-      html_table = ifelse(is.na(colval), '', stringi::stri_paste('\n', html_table, '<tr><th>', col, '</th><td>', colval, '</td></tr>'))
+      html_table = stringi::stri_paste('\n', html_table, ifelse(is.na(colval), '', stringi::stri_paste('<tr><th>', col, '</th><td>', colval, '</td></tr>')))
     }
     add_tag(html_table, 'table', tag_attr(class='meta_table', style=attr_style(`border-spacing`= '0px')))
   } else ''

--- a/R/html_misc.r
+++ b/R/html_misc.r
@@ -59,21 +59,22 @@ str_is_lead <- function(x) {
 #'
 #' @param meta a data.frame where each row represents the meta data for a document
 #' @param ignore_col optionally, a character vector with names of metadata columns to ignore
+#' @param drop.missing if TRUE, omit missing meta rows instead of printing empty value
 #'
 #' @return a character vector where each value contains a string for an html table.
 #' @export
 #' @examples
 #' tabs = create_meta_tables(sotu_data$meta)
 #' tabs[1]
-create_meta_tables <- function(meta, ignore_col=NULL) {
+create_meta_tables <- function(meta, ignore_col=NULL, drop.missing=FALSE) {
   if (ncol(meta) > 0) {
     html_table = ''
     for (col in colnames(meta)) {
       if (col == 'NAVIGATION_STRING') next
       if (col %in% ignore_col) next
       colval = as.character(meta[[col]])
-      colval[is.na(colval)] = ''
-      html_table = stringi::stri_paste('\n', html_table, '<tr><th>', col, '</th><td>', colval, '</td></tr>')
+      if (!drop.missing) colval[is.na(colval)] = ''
+      html_table = ifelse(is.na(colval), '', stringi::stri_paste('\n', html_table, '<tr><th>', col, '</th><td>', colval, '</td></tr>'))
     }
     add_tag(html_table, 'table', tag_attr(class='meta_table', style=attr_style(`border-spacing`= '0px')))
   } else ''

--- a/R/tokenvis.r
+++ b/R/tokenvis.r
@@ -22,6 +22,7 @@
 #'                  unique non-NA items in the navigation.
 #' @param style_col1 Color of the browser header
 #' @param style_col2 Color of the browser background
+#' @param drop.missing.meta if TRUE, omit missing meta rows instead of printing empty value
 #'
 #' @return The name of the file where the browser is saved. Can be opened conveniently from within R using browseUrl()
 #' @export
@@ -35,10 +36,10 @@
 #' if (interactive()) {
 #' browseURL(url)     ## view in default webbrowser
 #' }
-create_browser <- function(tokens, meta=NULL, doc_col='doc_id', token_col='token', space_col=NULL, doc_nav=NULL, token_nav=NULL, filename=NULL, css_str=NULL, header='', subheader='', n=TRUE, navfilter=TRUE, top_nav=NULL, thres_nav=1, colors=NULL, style_col1="#7D1935", style_col2="#F5F3EE"){
+create_browser <- function(tokens, meta=NULL, doc_col='doc_id', token_col='token', space_col=NULL, doc_nav=NULL, token_nav=NULL, filename=NULL, css_str=NULL, header='', subheader='', n=TRUE, navfilter=TRUE, top_nav=NULL, thres_nav=1, colors=NULL, style_col1="#7D1935", style_col2="#F5F3EE", drop.missing.meta=FALSE){
   tokens[[doc_col]] = factor(as.character(tokens[[doc_col]]), levels=unique(tokens[[doc_col]]))
 
-  docs = wrap_documents(tokens, meta, doc_col, token_col, space_col, nav=doc_nav, token_nav = token_nav, top_nav=top_nav, thres_nav=thres_nav)
+  docs = wrap_documents(tokens, meta, doc_col, token_col, space_col, nav=doc_nav, token_nav = token_nav, top_nav=top_nav, thres_nav=thres_nav, drop.missing.meta=drop.missing.meta)
   docstring = stringi::stri_paste(docs, collapse='\n\n')
 
   doc_ids = unique(tokens[[doc_col]])

--- a/R/wrap_documents.r
+++ b/R/wrap_documents.r
@@ -1,12 +1,12 @@
-create_doc_headers <- function(meta, doc_col='doc_id', nav=doc_col) {
+create_doc_headers <- function(meta, doc_col='doc_id', nav=doc_col, drop.missing.meta=FALSE) {
   title = add_tag(meta[[doc_col]], 'doc_id')
 
   if (!is.null(nav)) {
     navtags = add_tag(nav, 'div', tag_attr(style=attr_style(display="none")))
-    meta = create_meta_tables(meta, ignore_col = doc_col)
+    meta = create_meta_tables(meta, ignore_col = doc_col, drop.missing=drop.missing.meta)
     stringi::stri_paste(title, navtags, meta, sep='\n')
   } else {
-    meta = create_meta_tables(meta, ignore_col = doc_col)
+    meta = create_meta_tables(meta, ignore_col = doc_col, drop.missing=drop.missing.meta)
     stringi::stri_paste(title, meta, sep='\n')
   }
 
@@ -67,6 +67,7 @@ pretty_text_wrap <- function(x){
 #' @param token_nav  Alternative to nav (which uses meta), a column in tokens used for navigation
 #' @param top_nav    If token_nav is used, navigation filters will only apply to the top x values with highest token occurence in a document
 #' @param thres_nav  Like top_nav, but specifying a threshold for the minimum number of tokens.
+#' @param drop.missing.meta if TRUE, omit missing meta rows instead of printing empty value
 #'
 #' @return A named vector, with document ids as names and the document html strings as values
 #' @export
@@ -74,7 +75,7 @@ pretty_text_wrap <- function(x){
 #' docs = wrap_documents(sotu_data$tokens, sotu_data$meta)
 #' head(names(docs))
 #' docs[[1]]
-wrap_documents <- function(tokens, meta, doc_col='doc_id', token_col='token', space_col=NULL, nav=doc_col, token_nav=NULL, top_nav=NULL, thres_nav=NULL) {
+wrap_documents <- function(tokens, meta, doc_col='doc_id', token_col='token', space_col=NULL, nav=doc_col, token_nav=NULL, top_nav=NULL, thres_nav=NULL, drop.missing.meta=FALSE) {
   if (!methods::is(tokens, 'data.frame')) tokens = as.data.frame(tokens)
   doc_id = unique(tokens[[doc_col]])
   if (!is.null(meta)) {
@@ -88,10 +89,10 @@ wrap_documents <- function(tokens, meta, doc_col='doc_id', token_col='token', sp
 
   if (!is.null(token_nav)) {
     nav = token_nav_string(tokens, meta, doc_col, token_nav, top_nav, thres_nav)
-    header = create_doc_headers(meta, doc_col = doc_col, nav=nav)
+    header = create_doc_headers(meta, doc_col = doc_col, nav=nav, drop.missing.meta=drop.missing.meta)
   } else {
     nav = if (is.null(nav)) NULL else sprintf('<tag>%s</tag>', meta[[nav]])
-    header = create_doc_headers(meta, doc_col = doc_col, nav= nav)
+    header = create_doc_headers(meta, doc_col = doc_col, nav= nav, drop.missing.meta=drop.missing.meta)
   }
 
   texts = wrap_tokens(tokens, doc_col=doc_col, token_col=token_col, space_col=space_col)


### PR DESCRIPTION
currently if the meta contains missing values it will show them in the article with an empty value. This PR adds an argument to hide those values instead (for the documents where it is missing)